### PR TITLE
Fix macOS build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,34 @@ if (WORK_CONTRACT_BUILD_BENCHMARK)
     fetch_dependency("https://github.com/fmtlib/fmt.git;master")
     fetch_dependency("https://github.com/cameron314/concurrentqueue.git;master")
     #fetch_dependency("https://github.com/boostorg/lockfree.git;master")
-    fetch_dependency("https://github.com/erez-strauss/lockfree_mpmc_queue.git;master")
+
+    # Handle lockfree_mpmc_queue - on non-Linux platforms, just fetch headers to avoid build issues
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # On Linux, use normal fetch_dependency which builds the library
+        fetch_dependency("https://github.com/erez-strauss/lockfree_mpmc_queue.git;master")
+    else()
+        # On other platforms (macOS, Windows), only fetch headers - building fails due to x86 intrinsics
+        if ("${_lockfree_mpmc_queue_src_path}" STREQUAL "")
+            message("Fetching Content: lockfree_mpmc_queue (headers only)")
+            FetchContent_Declare(
+                lockfree_mpmc_queue
+                GIT_REPOSITORY "https://github.com/erez-strauss/lockfree_mpmc_queue.git"
+                GIT_TAG master
+                SOURCE_DIR "${CMAKE_BINARY_DIR}/lockfree_mpmc_queue-src"
+                BINARY_DIR "${CMAKE_BINARY_DIR}/lockfree_mpmc_queue-build"
+            )
+            FetchContent_Populate(lockfree_mpmc_queue)
+            # Don't add_subdirectory to avoid build issues on non-Linux platforms
+            set(_lockfree_mpmc_queue_src_path ${CMAKE_BINARY_DIR}/lockfree_mpmc_queue-src CACHE STRING "")
+        endif()
+    endif()
+
     fetch_dependency("https://github.com/google/googletest.git;main")
+
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-    set(TBB_BUILD_TESTS OFF)
-    set(TBB_BUILD_SHARED OFF)
-    set(TBB_BUILD_STATIC ON)
+    set(TBB_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(TBB_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(TBB_BUILD_STATIC ON CACHE BOOL "" FORCE)
     fetch_dependency("https://github.com/wjakob/tbb.git;master")
 endif(WORK_CONTRACT_BUILD_BENCHMARK)
 

--- a/src/executable/1_basic_contract_execution/CMakeLists.txt
+++ b/src/executable/1_basic_contract_execution/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(1_basic_contract_execution PUBLIC ${_work_contract_di
 target_link_libraries(1_basic_contract_execution 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(1_basic_contract_execution PRIVATE rt)
+endif()

--- a/src/executable/1_basic_contract_execution/main.cpp
+++ b/src/executable/1_basic_contract_execution/main.cpp
@@ -1,6 +1,6 @@
 #include <library/work_contract.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 
 int main() 
 {
@@ -8,7 +8,7 @@ int main()
     bcpp::work_contract_group group;
 
     // Start worker thread to process scheduled work contracts
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract();

--- a/src/executable/2_recurrent_scheduling/CMakeLists.txt
+++ b/src/executable/2_recurrent_scheduling/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(2_recurrent_scheduling PUBLIC ${_work_contract_dir}/s
 target_link_libraries(2_recurrent_scheduling 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(2_recurrent_scheduling PRIVATE rt)
+endif()

--- a/src/executable/2_recurrent_scheduling/main.cpp
+++ b/src/executable/2_recurrent_scheduling/main.cpp
@@ -1,11 +1,11 @@
 #include <library/work_contract.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 
 int main() 
 {
     bcpp::work_contract_group group;
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract();

--- a/src/executable/3_custom_cleanup/CMakeLists.txt
+++ b/src/executable/3_custom_cleanup/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(3_custom_cleanup PUBLIC ${_work_contract_dir}/src ${_
 target_link_libraries(3_custom_cleanup 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(3_custom_cleanup PRIVATE rt)
+endif()

--- a/src/executable/3_custom_cleanup/main.cpp
+++ b/src/executable/3_custom_cleanup/main.cpp
@@ -1,11 +1,11 @@
 #include <library/work_contract.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 
 int main() 
 {
     bcpp::work_contract_group group;
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract();

--- a/src/executable/4_blocking_mode/CMakeLists.txt
+++ b/src/executable/4_blocking_mode/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(4_blocking_mode PUBLIC ${_work_contract_dir}/src ${_i
 target_link_libraries(4_blocking_mode 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(4_blocking_mode PRIVATE rt)
+endif()

--- a/src/executable/4_blocking_mode/main.cpp
+++ b/src/executable/4_blocking_mode/main.cpp
@@ -1,12 +1,12 @@
 #include <library/work_contract.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 #include <chrono>
 
 int main() 
 {
     bcpp::blocking_work_contract_group group;
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract(/*std::chrono::seconds(1)*/); // use infinite wait - note: we could use wait with timeout here as well

--- a/src/executable/5_exception_handling/CMakeLists.txt
+++ b/src/executable/5_exception_handling/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(5_exception_handling PUBLIC ${_work_contract_dir}/src
 target_link_libraries(5_exception_handling 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(5_exception_handling PRIVATE rt)
+endif()

--- a/src/executable/5_exception_handling/main.cpp
+++ b/src/executable/5_exception_handling/main.cpp
@@ -1,11 +1,11 @@
 #include <library/work_contract.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 
 int main() 
 {
     bcpp::work_contract_group group;
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract();

--- a/src/executable/6_data_ingress/CMakeLists.txt
+++ b/src/executable/6_data_ingress/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(6_data_ingress PUBLIC ${_work_contract_dir}/src ${_in
 target_link_libraries(6_data_ingress 
 PRIVATE
     pthread
-    rt
     work_contract
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(6_data_ingress PRIVATE rt)
+endif()

--- a/src/executable/6_data_ingress/main.cpp
+++ b/src/executable/6_data_ingress/main.cpp
@@ -1,13 +1,13 @@
 #include <library/work_contract.h>
 #include <include/spsc_fixed_queue.h>
+#include <include/jthread.h>
 #include <iostream>
-#include <thread>
 #include <chrono>
 
 int main() 
 {
     bcpp::work_contract_group group;
-    std::jthread worker([&group](auto stopToken) 
+    bcpp::detail::jthread worker([&group](auto stopToken)
             {
                 while (not stopToken.stop_requested())
                     group.execute_next_contract();

--- a/src/executable/benchmark/CMakeLists.txt
+++ b/src/executable/benchmark/CMakeLists.txt
@@ -15,9 +15,13 @@ PRIVATE
 target_link_libraries(benchmark 
 PRIVATE
     pthread
-    rt
     work_contract
     tbb_static
     fmt
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(benchmark PRIVATE rt)
+endif()
 

--- a/src/executable/signal_tree_benchmark/main.cpp
+++ b/src/executable/signal_tree_benchmark/main.cpp
@@ -17,6 +17,7 @@
 #include <ratio>
 #include <functional>
 
+#include <include/jthread.h>
 #include <include/signal_tree.h>
 
 // it might look a bit odd to hard code the cpus to use in the benchmark
@@ -38,10 +39,16 @@ bool set_cpu_affinity
     int value
 )
 {
+#ifdef __linux__
     cpu_set_t cpuSet;
     CPU_ZERO(&cpuSet);
     CPU_SET(value, &cpuSet);
     return (pthread_setaffinity_np(pthread_self(), sizeof(cpuSet), &cpuSet) == 0);
+#else
+    // macOS doesn't support CPU affinity via pthread_setaffinity_np
+    (void)value;
+    return true;
+#endif
 }
 
 
@@ -105,9 +112,9 @@ int main
                     activeThreadCount--;
                 };
 
-        std::vector<std::jthread> threads(num_threads);
+        std::vector<bcpp::detail::jthread> threads(num_threads);
         for (auto & thread : threads)
-            thread = std::jthread(test);
+            thread = bcpp::detail::jthread(test);
 
         while (activeThreadCount != num_threads)
             ;

--- a/src/include/atomic_shared_ptr.h
+++ b/src/include/atomic_shared_ptr.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#if !defined(__cpp_lib_atomic_shared_ptr) || __cpp_lib_atomic_shared_ptr < 201711L
+#include <mutex>
+
+namespace bcpp::detail {
+
+    template<typename T>
+    class atomic_shared_ptr {
+        std::shared_ptr<T> ptr_;
+        mutable std::mutex mtx_;
+    public:
+        atomic_shared_ptr() = default;
+        atomic_shared_ptr(std::shared_ptr<T> p) : ptr_(std::move(p)) {}
+
+        std::shared_ptr<T> load() const {
+            std::lock_guard<std::mutex> lock(mtx_);
+            return ptr_;
+        }
+
+        std::shared_ptr<T> exchange(std::shared_ptr<T> desired) {
+            std::lock_guard<std::mutex> lock(mtx_);
+            std::shared_ptr<T> old = std::move(ptr_);
+            ptr_ = std::move(desired);
+            return old;
+        }
+
+        void store(std::shared_ptr<T> desired) {
+            std::lock_guard<std::mutex> lock(mtx_);
+            ptr_ = std::move(desired);
+        }
+    };
+
+} // namespace bcpp::detail
+#else
+
+namespace bcpp::detail {
+    template<typename T>
+    using atomic_shared_ptr = std::atomic<std::shared_ptr<T>>;
+}
+#endif

--- a/src/include/jthread.h
+++ b/src/include/jthread.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <thread>
+
+#if not defined(__cpp_lib_jthread) || __cpp_lib_jthread < 201911L
+    #include <atomic>
+    #include <functional>
+
+namespace bcpp::detail {
+
+// Simple stop_token implementation
+class stop_token
+{
+    std::atomic<bool> * stop_flag_;
+
+public:
+    explicit stop_token(std::atomic<bool> * flag)
+    : stop_flag_(flag)
+    { }
+
+    bool stop_requested() const noexcept { return stop_flag_->load(); }
+};
+
+// Simple jthread implementation with stop_token support
+class jthread
+{
+    struct Impl
+    {
+        std::thread thread;
+        std::atomic<bool> stop_flag{false};
+    };
+
+    std::unique_ptr<Impl> impl_;
+
+public:
+    jthread() = default;
+
+    template <typename F, typename... Args>
+    explicit jthread(F && f, Args &&... args)
+    : impl_(std::make_unique<Impl>())
+    {
+        // Check if callable accepts stop_token as first argument
+        if constexpr (std::is_invocable_v<F, stop_token, Args...>) {
+            impl_->thread = std::thread(
+                std::forward<F>(f),
+                stop_token(&impl_->stop_flag),
+                std::forward<Args>(args)...);
+        } else {
+            impl_->thread = std::thread(
+                std::forward<F>(f),
+                std::forward<Args>(args)...);
+        }
+    }
+
+    jthread(jthread &&) = default;
+    jthread & operator = (jthread &&) = default;
+
+    ~jthread()
+    {
+        if (impl_ && impl_->thread.joinable()) {
+            request_stop();
+            join();
+        }
+    }
+
+    void request_stop() noexcept
+    {
+        if (impl_) {
+            impl_->stop_flag.store(true);
+        }
+    }
+
+    void join()
+    {
+        if (impl_ && impl_->thread.joinable()) {
+            impl_->thread.join();
+        }
+    }
+
+    bool joinable() const noexcept { return impl_ && impl_->thread.joinable(); }
+};
+
+} // namespace bcpp::detail
+#else
+    #include <stop_token>
+
+namespace bcpp::detail {
+using jthread = std::jthread;
+using stop_token = std::stop_token;
+}
+#endif

--- a/src/include/signal_tree/tree.h
+++ b/src/include/signal_tree/tree.h
@@ -119,18 +119,18 @@ namespace bcpp
     } // namespace bcpp::implementation::signal_tree
 
 
-    template <std::size_t N> 
+    template <std::uint64_t N>
     using signal_tree = implementation::signal_tree::tree<implementation::signal_tree::select_tree_size(N)>;
 
 } // namespace bcpp
 
 
 //=============================================================================
-template <std::size_t N>
+template <std::uint64_t N>
 inline std::pair<bool, bool> bcpp::implementation::signal_tree::tree<N>::set
 (
     // set the leaf node associated with the index to 1
-    signal_index signalIndex
+    bcpp::signal_index signalIndex
 ) noexcept 
 {
     return rootLevel_.set(signalIndex);
@@ -138,7 +138,7 @@ inline std::pair<bool, bool> bcpp::implementation::signal_tree::tree<N>::set
 
 
 //=============================================================================
-template <std::size_t N>
+template <std::uint64_t N>
 inline bool bcpp::implementation::signal_tree::tree<N>::empty
 (
     // returns true if no leaf nodes are 'set' (root count is zero)
@@ -150,14 +150,14 @@ inline bool bcpp::implementation::signal_tree::tree<N>::empty
 
 
 //=============================================================================
-template <std::size_t N>
+template <std::uint64_t N>
 template <template <std::uint64_t, std::uint64_t> class select_function>
 inline auto bcpp::implementation::signal_tree::tree<N>::select 
 (
     // select and return the index of a leaf which is 'set'
     // return invalid_signal_index if no leaf is 'set' (empty tree)
     std::uint64_t bias
-) noexcept -> std::pair<signal_index, bool>
+) noexcept -> std::pair<bcpp::signal_index, bool>
 {
     static auto constexpr number_of_bias_bits = (65 - minimum_bit_count(capacity));
     bias <<= number_of_bias_bits;

--- a/src/library/work_contract/CMakeLists.txt
+++ b/src/library/work_contract/CMakeLists.txt
@@ -7,8 +7,12 @@ add_library(work_contract
 
 target_link_libraries(work_contract 
     pthread
-    rt
 )
+
+# rt library is only available on Linux
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(work_contract rt)
+endif()
 
 
 target_include_directories(work_contract

--- a/src/library/work_contract/work_contract.h
+++ b/src/library/work_contract/work_contract.h
@@ -2,11 +2,10 @@
 
 #include <include/synchronization_mode.h>
 #include <include/non_copyable.h>
+#include <include/atomic_shared_ptr.h>
 
-#include <atomic>
 #include <cstdint>
 #include <utility>
-#include <memory>
 
 
 namespace bcpp::implementation
@@ -64,7 +63,7 @@ namespace bcpp::implementation
 
         work_contract_group_type *   owner_{};
 
-        std::atomic<std::shared_ptr<typename work_contract_group_type::release_token>> releaseToken_;
+        detail::atomic_shared_ptr<typename work_contract_group_type::release_token> releaseToken_;
 
         id_type                 id_{};
 

--- a/src/library/work_contract/work_contract_group.cpp
+++ b/src/library/work_contract/work_contract_group.cpp
@@ -78,7 +78,7 @@ auto bcpp::implementation::work_contract_group<T>::get_available_contract
         auto subTreeIndex (nextAvailableTreeIndex_++ & subTreeMask_);
         if (!available_[subTreeIndex].empty())
         {
-            if (auto [signalIndex, _] = available_[subTreeIndex].select<largest_child_selector>(0); signalIndex != ~0ull)
+            if (auto [signalIndex, _] = available_[subTreeIndex].template select<largest_child_selector>(0); signalIndex != ~0ull)
             {
                 work_contract_id workContractId(subTreeIndex * signal_tree_capacity);
                 workContractId += signalIndex;


### PR DESCRIPTION
  - Conditionally handle lockfree_mpmc_queue: use fetch_dependency on Linux, headers-only on macOS
  - Add atomic_shared_ptr.h and jthread.h compatibility headers
  - Update examples and library code for macOS compatibility